### PR TITLE
package updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirigera"
 description = "Manage your IKEA Trådfri devices with Rust"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Simon Sawert<simon@sawert.se>"]
 license = "MIT"
@@ -12,24 +12,26 @@ repository = "https://github.com/bombsimon/dirigera-rs"
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4"
-http = "0.2"
+http = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-hyper-rustls = "0.24.2"
-rustls = { version = "0.21.8", features = ["dangerous_configuration"] }
-hyper = { version ="0.14.27", features = ["full"] }
+hyper-rustls = "0.27"
+rustls = { version = "0.23" }
+hyper = { version = "1.9", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
+http-body-util = "0.1"
 
 # Dependencies needed to run the binary to generate a token. Can be skipped if
 # already obtained token or after token is obtained.
-tokio = { version = "1.33", features = ["full"], optional = true}
-toml = { version = "0.5", optional = true }
-pkce = { version = "0.1.1", optional = true }
-url = { version = "2.4", optional = true }
-reqwest = { version = "0.11.22", features = ["json"], optional = true }
+tokio = { version = "1.52", features = ["full"], optional = true }
+toml = { version = "1.1", optional = true }
+pkce = { version = "0.2", optional = true }
+url = { version = "2.5", optional = true }
+reqwest = { version = "0.13", features = ["json"], optional = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = "0.10"
 
 [features]
 default = []

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -4,7 +4,14 @@
 //! TLS verification. You also need a bearer token which is obtain via OAuth 2. Configuration for
 //! TLS and tool to get a token is both available under the [`danger`](crate::danger) module and the
 //! `config` feature flag respectively.
-use hyper::service::Service;
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+#[cfg(feature = "config")]
+use hyper_util::rt::TokioExecutor;
+#[cfg(feature = "config")]
 use serde::Deserialize;
 
 use std::collections::HashMap;
@@ -18,7 +25,7 @@ const DIRIGERA_API_VERSION: &str = "v1";
 /// it.
 #[derive(Debug)]
 pub struct Hub {
-    client: hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>,
+    client: Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
     ip_address: std::net::Ipv4Addr,
     token: String,
 }
@@ -55,7 +62,7 @@ impl Default for Hub {
             .enable_http1()
             .build();
 
-        let client = hyper::Client::builder().build::<_, hyper::Body>(https);
+        let client = Client::builder(TokioExecutor::new()).build(https);
 
         Self::new(client, config.ip_address, config.token)
     }
@@ -65,7 +72,7 @@ impl Hub {
     /// Create a new instance of the [`Hub`]. You need to construct your own [`hyper]` client and
     /// use it together with the IP address and bearer token for the [`Hub`].
     pub fn new(
-        client: hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>,
+        client: Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
         ip_address: std::net::Ipv4Addr,
         token: String,
     ) -> Self {
@@ -80,8 +87,8 @@ impl Hub {
         &self,
         method: http::Method,
         path: &str,
-        body: Option<hyper::Body>,
-    ) -> anyhow::Result<http::Request<hyper::Body>> {
+        body: Option<Full<Bytes>>,
+    ) -> anyhow::Result<http::Request<Full<Bytes>>> {
         let uri: hyper::Uri = format!(
             "https://{}:{}/{}{}",
             self.ip_address, DIRIGERA_PORT, DIRIGERA_API_VERSION, path,
@@ -97,18 +104,18 @@ impl Hub {
 
         let req = match body {
             Some(body) => request.body(body),
-            None => request.body(hyper::Body::empty()),
+            None => request.body(Full::default()),
         };
 
         req.map_err(|err| anyhow::anyhow!(err))
     }
 
-    async fn deserialize_response<T>(response: http::Response<hyper::Body>) -> anyhow::Result<T>
+    async fn deserialize_response<T>(response: http::Response<Incoming>) -> anyhow::Result<T>
     where
         T: serde::de::DeserializeOwned,
     {
         let (_, body) = response.into_parts();
-        let body = hyper::body::to_bytes(body).await?;
+        let body = body.collect().await?.to_bytes();
 
         serde_json::from_slice(body.as_ref()).map_err(|err| anyhow::anyhow!(err))
     }
@@ -118,7 +125,7 @@ impl Hub {
     pub async fn devices(&mut self) -> anyhow::Result<Vec<crate::Device>> {
         Self::deserialize_response(
             self.client
-                .call(self.create_request(http::Method::GET, "/devices", None)?)
+                .request(self.create_request(http::Method::GET, "/devices", None)?)
                 .await?,
         )
         .await
@@ -128,7 +135,7 @@ impl Hub {
     pub async fn device(&mut self, id: &str) -> anyhow::Result<crate::Device> {
         Self::deserialize_response(
             self.client
-                .call(self.create_request(
+                .request(self.create_request(
                     http::Method::GET,
                     format!("/devices/{}", id).as_str(),
                     None,
@@ -164,10 +171,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -206,10 +213,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -250,10 +257,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -304,10 +311,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -359,10 +366,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -391,10 +398,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -435,10 +442,10 @@ impl Hub {
         let body: String = serde_json::to_string(&vec![body])?;
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::PATCH,
                 format!("/devices/{}", inner.id).as_str(),
-                Some(hyper::Body::from(body)),
+                Some(Full::new(Bytes::from(body))),
             )?)
             .await?;
 
@@ -452,7 +459,7 @@ impl Hub {
     pub async fn scenes(&mut self) -> anyhow::Result<Vec<crate::Scene>> {
         Self::deserialize_response(
             self.client
-                .call(self.create_request(http::Method::GET, "/scenes", None)?)
+                .request(self.create_request(http::Method::GET, "/scenes", None)?)
                 .await?,
         )
         .await
@@ -462,7 +469,7 @@ impl Hub {
     pub async fn scene(&mut self, id: &str) -> anyhow::Result<crate::Scene> {
         Self::deserialize_response(
             self.client
-                .call(self.create_request(
+                .request(self.create_request(
                     http::Method::GET,
                     format!("/scenes/{}", id).as_str(),
                     None,
@@ -477,10 +484,10 @@ impl Hub {
         let inner = scene.inner();
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::POST,
                 format!("/scenes/{}/trigger", inner.id).as_str(),
-                Some(hyper::Body::empty()),
+                Some(Full::default()),
             )?)
             .await?;
 
@@ -492,10 +499,10 @@ impl Hub {
         let inner = scene.inner();
 
         self.client
-            .call(self.create_request(
+            .request(self.create_request(
                 http::Method::POST,
                 format!("/scenes/{}/undo", inner.id).as_str(),
-                Some(hyper::Body::empty()),
+                Some(Full::default()),
             )?)
             .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,25 +39,54 @@ where
 /// A module that is used to disable TLS verification. This is used because the Dirigera HUB uses
 /// HTTPS but with a self signed certificate.
 pub mod danger {
+    #[derive(Debug)]
     pub struct NoCertificateVerification;
 
-    impl rustls::client::ServerCertVerifier for NoCertificateVerification {
+    impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
         fn verify_server_cert(
             &self,
-            _end_entity: &rustls::Certificate,
-            _intermediates: &[rustls::Certificate],
-            _server_name: &rustls::client::ServerName,
-            _scts: &mut dyn Iterator<Item = &[u8]>,
+            _end_entity: &rustls::pki_types::CertificateDer,
+            _intermediates: &[rustls::pki_types::CertificateDer],
+            _server_name: &rustls::pki_types::ServerName,
             _ocsp_response: &[u8],
-            _now: std::time::SystemTime,
-        ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
-            Ok(rustls::client::ServerCertVerified::assertion())
+            _now: rustls::pki_types::UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &rustls::pki_types::CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            let supported_algos = rustls::crypto::CryptoProvider::get_default()
+                .ok_or(rustls::Error::General("no crypto provider".into()))?
+                .signature_verification_algorithms;
+            rustls::crypto::verify_tls12_signature(message, cert, dss, &supported_algos)
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &rustls::pki_types::CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            let supported_algos = rustls::crypto::CryptoProvider::get_default()
+                .ok_or(rustls::Error::General("no crypto provider".into()))?
+                .signature_verification_algorithms;
+            rustls::crypto::verify_tls13_signature(message, cert, dss, &supported_algos)
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            rustls::crypto::CryptoProvider::get_default()
+                .map(|p| p.signature_verification_algorithms.supported_schemes())
+                .unwrap_or_default()
         }
     }
 
     pub fn tls_no_verify() -> rustls::ClientConfig {
         let mut tls = rustls::ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(rustls::RootCertStore::empty())
             .with_no_client_auth();
 


### PR DESCRIPTION
Update packages to their newest versions, implementing the requisite API changes.

I'm not very proud of the implementation of `ServerCertVerifier::supported_verify_schemes` for `NoCertificateVerification`, but there doesn't seem to be a simple "list everything rustls supports" function in the rustls API.